### PR TITLE
Fix typescript errors in slideshow components

### DIFF
--- a/src/components/Slideshow.tsx
+++ b/src/components/Slideshow.tsx
@@ -24,8 +24,8 @@ const Slideshow: React.FC<SlideshowProps> = ({
   const [fadeClass, setFadeClass] = useState('fade-in');
   
   const slideshowRef = useRef<HTMLDivElement>(null);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
-  const progressRef = useRef<NodeJS.Timeout | null>(null);
+  const intervalRef = useRef<number | null>(null);
+  const progressRef = useRef<number | null>(null);
 
   // Progress bar animation
   const startProgress = useCallback(() => {
@@ -36,12 +36,12 @@ const Slideshow: React.FC<SlideshowProps> = ({
     const steps = interval / progressInterval;
     let currentStep = 0;
 
-    progressRef.current = setInterval(() => {
+    progressRef.current = window.setInterval(() => {
       currentStep++;
       setProgress((currentStep / steps) * 100);
       
       if (currentStep >= steps) {
-        if (progressRef.current) clearInterval(progressRef.current);
+        if (progressRef.current) window.clearInterval(progressRef.current);
       }
     }, progressInterval);
   }, [interval]);
@@ -50,7 +50,7 @@ const Slideshow: React.FC<SlideshowProps> = ({
   useEffect(() => {
     if (isPlaying && images.length > 1) {
       startProgress();
-      intervalRef.current = setInterval(() => {
+      intervalRef.current = window.setInterval(() => {
         setFadeClass('fade-out');
         setTimeout(() => {
           setCurrentSlide((prev) => (prev + 1) % images.length);
@@ -60,8 +60,8 @@ const Slideshow: React.FC<SlideshowProps> = ({
     }
 
     return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-      if (progressRef.current) clearInterval(progressRef.current);
+      if (intervalRef.current) window.clearInterval(intervalRef.current);
+      if (progressRef.current) window.clearInterval(progressRef.current);
     };
   }, [isPlaying, interval, images.length, startProgress]);
 

--- a/src/components/SlideshowExample.tsx
+++ b/src/components/SlideshowExample.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Slideshow from './Slideshow';
 
 // Example of how to use the Slideshow component with your own images
@@ -11,14 +10,6 @@ const SlideshowExample = () => {
   // import image3 from '../assets/images/image3.jpg';
   // 
   // const localImages = [image1, image2, image3];
-
-  // Option 2: Using images from the public folder
-  const publicImages = [
-    '/images/slide1.jpg',
-    '/images/slide2.jpg', 
-    '/images/slide3.jpg',
-    '/images/slide4.jpg'
-  ];
 
   // Option 3: Using external URLs (like Unsplash)
   const externalImages = [

--- a/src/pages/Slideshow.tsx
+++ b/src/pages/Slideshow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Slideshow from '../components/Slideshow';
 
 const SlideshowPage = () => {


### PR DESCRIPTION
Fix TypeScript build errors to enable successful Netlify deployment.

The build failed due to TypeScript errors related to `NodeJS.Timeout` and `setInterval`/`clearInterval` type mismatches in a browser environment. This PR explicitly uses `window.setInterval`/`window.clearInterval` and `number` for interval types to ensure correct DOM API type inference. Unused `React` imports and `publicImages` variable were also removed.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a3a35b96-0d2f-43ca-88d3-115fa3b77d50) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a3a35b96-0d2f-43ca-88d3-115fa3b77d50)